### PR TITLE
set -e in publishcatalog to exit on failure

### DIFF
--- a/bin/publish-catalog
+++ b/bin/publish-catalog
@@ -1,4 +1,4 @@
-set +x
+set -e
 if [[ "$DEBUG" = "true" ]];then
   set -x
 fi
@@ -120,7 +120,6 @@ gitPublishFunc(){
   loginfo "variable substitution done..."
 
   git add "$REPO_DIR/charts/$CATALOG_NAME/$VERSION/"
-  git diff-index --quiet HEAD --ignore-submodules
   git commit --allow-empty -m "$MESSAGE"
   git push $PUSH_OPTION
 }


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/17252

Problem:
When the deploy key is invalid and git clone fails, the rest commands still execute

Solution:
Add `set -e`. Jenkins use it by default in shell step but it is not propagate into the script context. Also remove git diff-index so as to do commit regardless of the differences