### PR TITLE
Fix waitAppActive loop

### DIFF
--- a/bin/apply-app
+++ b/bin/apply-app
@@ -65,6 +65,7 @@ prepareFunc(){
 }
 
 waitAppActiveFunc(){
+  loginfo "waiting $APP_NAME to be active..."
   count=0
   limit=60
   until test "$state" = "active" || test $count -gt $limit
@@ -79,10 +80,11 @@ waitAppActiveFunc(){
       exiterr "$transitioningMessage"
     fi
     sleep 5
+    count=$((count + 1))
+    if [[ $count -gt $limit ]];then
+      exiterr "timeout waiting $APP_NAME to be active"
+    fi
   done
-  if [[ $count -gt $limit ]];then
-    exiterr "timeout waiting $APP_NAME to be active"
-  fi
 }
 
 installAppFunc(){


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/17570

Problem:
When the deployed app fails to be an active state, the step pends.

Solution:
Fix termination in the waitAppActive loop.