### PR TITLE
Trim port in netrc machine

### DIFF
--- a/bin/publish-catalog
+++ b/bin/publish-catalog
@@ -69,7 +69,9 @@ prepareFunc(){
     chmod 600 ~/.ssh/id_rsa
   else
     #prepare netrc file
-    MACHINE=$(echo $GIT_URL | sed -e "s/[^/]*\/\/\([^@]*@\)\?\([^/]*\).*/\2/")
+    if [[ -z "$MACHINE" ]];then
+      MACHINE=$(echo $GIT_URL | sed -e "s/[^/]*\/\/\([^@]*@\)\?\([^/:]*\).*/\2/")
+    fi
     printf "machine %s\nlogin %s\npassword %s\n" "$MACHINE" "$USERNAME" "$PASSWORD" > ~/.netrc
     chmod 600 ~/.netrc
   fi


### PR DESCRIPTION
Address issue:
https://github.com/rancher/rancher/issues/20563

Problem:
Fails to publish catalogs to the repo if it is in [ip:port] format. The machine in .netrc file is port independent, and it does not match if the port is included.

Solution:
Trim [:port] in netrc machine.