### PR TITLE
Bump to Nginx/Alpine version nginx:1.21.6-alpine

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.0-alpine
+FROM nginx:1.21.6-alpine
 
 ARG RANCHER_CLI_VERSION=v2.3.0
 RUN apk -U --no-cache add bash curl wget git ca-certificates openssl openssh\


### PR DESCRIPTION
Bump to Nginx/Alpine version nginx:1.21.6-alpine

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>